### PR TITLE
[APP-266] Android에서 웹앱간 통신이 안되는 문제

### DIFF
--- a/src/screens/LibraryRecapScreen.tsx
+++ b/src/screens/LibraryRecapScreen.tsx
@@ -2,8 +2,9 @@ import {useEffect, useRef} from 'react';
 import WebView from 'react-native-webview';
 import {onMessageFromWebView, useAndroidBackPress} from '@uoslife/webview';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {StatusBar, View} from 'react-native';
+import {Platform, StatusBar, View} from 'react-native';
 import {useIsFocused, useNavigation} from '@react-navigation/core';
+
 import useUserState from '../hooks/useUserState';
 import storage from '../storage';
 
@@ -23,7 +24,7 @@ const LibraryRecapScreen = () => {
   const navigationGoBack = () => {
     navigation.goBack();
   };
-  useAndroidBackPress(webviewRef);
+  // useAndroidBackPress(webviewRef);
   return (
     <>
       <View
@@ -43,6 +44,7 @@ const LibraryRecapScreen = () => {
             navigationGoBack,
           })
         }
+        userAgent={Platform.OS === 'ios' ? 'ios' : 'android'}
       />
     </>
   );


### PR DESCRIPTION
# Key Changes

- Android에서 webview와 앱 간 통신이 안되는 문제를 해결했습니다.

# Details

- userAgent속성에 platform정보를 넘겨주고, @uoslife/webview에서 대응합니다.
- useAndroidBackPress훅을 적용 해제했습니다.


# Closes Issue

close #310 
