### PR TITLE
[APP-268] 수정된 포털연동 API 반영

### DIFF
--- a/src/api/core/methods.ts
+++ b/src/api/core/methods.ts
@@ -39,5 +39,10 @@ export const del = async <T extends unknown>(
   const deleteRes = body
     ? await apiClient.delete(url, {json: body})
     : await apiClient.delete(url);
-  return await deleteRes.json();
+  try {
+    const postJsonRes = (await deleteRes.json()) as KyJsonResponse<T>;
+    return postJsonRes;
+  } catch (error) {
+    return null as unknown as KyJsonResponse<T>;
+  }
 };

--- a/src/api/services/core/verification/verificationAPI.interface.ts
+++ b/src/api/services/core/verification/verificationAPI.interface.ts
@@ -1,9 +1,21 @@
 import {ServiceFunc} from '../../type';
 import * as Type from './verificationAPI.type';
 
-export default interface verificationService {
+export default interface VerificationService {
   portalVerification: ServiceFunc<
     Type.PortalVerificationParams,
     Type.PortalVerificationRes
+  >;
+  getPortalVerification: ServiceFunc<
+    Type.GetPortalVerificationParams,
+    Type.GetPortalVerificationRes
+  >;
+  deletePortalVerification: ServiceFunc<
+    Type.DeletePortalVerificationParams,
+    Type.DeletePortalVerificationRes
+  >;
+  representativePortalVerification: ServiceFunc<
+    Type.RepresentativePortalVerificationParams,
+    Type.RepresentativePortalVerificationRes
   >;
 }

--- a/src/api/services/core/verification/verificationAPI.ts
+++ b/src/api/services/core/verification/verificationAPI.ts
@@ -1,9 +1,18 @@
-import {post} from '../../../core/methods';
-import verificationService from './verificationAPI.interface';
+import {del, get, post} from '../../../core/methods';
+import VerificationService from './verificationAPI.interface';
 import * as Type from './verificationAPI.type';
 
-const verificationAPI: verificationService = {
+const verificationAPI: VerificationService = {
   portalVerification: params =>
     post<Type.PortalVerificationRes>('core/verification', params),
+  getPortalVerification: () =>
+    get<Type.GetPortalVerificationRes>('core/verification'),
+  deletePortalVerification: () =>
+    del<Type.DeletePortalVerificationRes>('core/verification'),
+  representativePortalVerification: params =>
+    post<Type.RepresentativePortalVerificationRes>(
+      'core/verification/representative',
+      params,
+    ),
 };
 export default verificationAPI;

--- a/src/api/services/core/verification/verificationAPI.type.ts
+++ b/src/api/services/core/verification/verificationAPI.type.ts
@@ -1,5 +1,24 @@
+type EmptifiedObject = {};
+export type PortalVerificationResType = {
+  studentId: string;
+  studentName: string;
+  status: string;
+  isRepresentative: boolean;
+};
+
 export type PortalVerificationParams = {
   username: string;
   password: string;
 };
-export type PortalVerificationRes = {};
+export type PortalVerificationRes = EmptifiedObject;
+
+export type GetPortalVerificationParams = EmptifiedObject;
+export type GetPortalVerificationRes = Array<PortalVerificationResType>;
+
+export type DeletePortalVerificationParams = EmptifiedObject;
+export type DeletePortalVerificationRes = EmptifiedObject;
+
+export type RepresentativePortalVerificationParams = {
+  studentNumber: string;
+};
+export type RepresentativePortalVerificationRes = PortalVerificationResType;

--- a/src/configs/toast/toastMessageProps.tsx
+++ b/src/configs/toast/toastMessageProps.tsx
@@ -18,6 +18,12 @@ const toastMessage = {
   notificationError: '알림 설정을 처리하는 중 문제가 발생했어요.',
   unRegisterTwiceUserError: '회원탈퇴 이력이 2회 이상인 유저입니다.',
 
+  // 포털 연동 관리
+  portalVerificationSuccess: '포털 연동을 성공적으로 변경했어요.',
+  portalVerificationError: '포털 연동을 처리하는 중 오류가 발생했어요.',
+  deletePortalVerificationSuccess: '포털 연동을 성공적으로 해지했어요.',
+  deletePortalVerificationError: '포털 연동을 해지하는 중 오류가 발생했어요.',
+
   SmsVerificationError: '전화번호 인증 과정에서 문제가 발생했어요.',
   loginDurationExpiredInfo: '로그인 기한이 만료되었어요.',
 
@@ -87,6 +93,20 @@ const toastMessageProps: {[T in ToastMessageType]: ShowToastProps} = {
       Linking.openURL(urls.CONTACT_UOSLIFE);
     },
     autoHide: false,
+  },
+  portalVerificationSuccess: {
+    title: toastMessage.portalVerificationSuccess,
+  },
+  portalVerificationError: {
+    type: 'error',
+    title: toastMessage.portalVerificationError,
+  },
+  deletePortalVerificationSuccess: {
+    title: toastMessage.deletePortalVerificationSuccess,
+  },
+  deletePortalVerificationError: {
+    type: 'error',
+    title: toastMessage.deletePortalVerificationError,
   },
   SmsVerificationError: {
     type: 'error',

--- a/src/navigators/MyPageStackNavigator.tsx
+++ b/src/navigators/MyPageStackNavigator.tsx
@@ -14,6 +14,7 @@ import {
 import SetNicknameScreen from '../screens/account/common/SetNicknameScreen';
 import VerificationScreen from '../screens/account/signIn/VerificationScreen';
 import PortalAuthenticationScreen from '../screens/account/common/PortalAuthenticationScreen';
+import PortalAuthenticationManagementScreen from '../screens/myPage/profile/PortalAuthenticationManagementScreen';
 
 export type MyPageStackParamList = {
   Mypage_main: undefined;
@@ -24,8 +25,9 @@ export type MyPageStackParamList = {
 
 export type MyPageProfileStackParamList = {
   Mypage_profile_Main: undefined;
-  Mypage_changeNickname: undefined;
+  Mypage_changeNickname: {isMyPage: boolean};
   Mypage_portalAuthentication: undefined;
+  Mypage_portalAuthenticationManagement: undefined;
   Mypage_changeNumber: undefined;
 };
 export type MypageProfileNavigationProp =
@@ -61,6 +63,10 @@ const MypageProfileNavigator = () => {
       <ProfileStack.Screen
         name="Mypage_portalAuthentication"
         component={PortalAuthenticationScreen}
+      />
+      <ProfileStack.Screen
+        name="Mypage_portalAuthenticationManagement"
+        component={PortalAuthenticationManagementScreen}
       />
       <ProfileStack.Screen
         name="Mypage_changeNumber"

--- a/src/screens/myPage/profile/MypageProfileScreen.tsx
+++ b/src/screens/myPage/profile/MypageProfileScreen.tsx
@@ -33,7 +33,8 @@ const MypageProfileScreen = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<MypageProfileNavigationProp>();
   const [selectedPhotoUri, openPhotoSelectionAlert] = usePhoto('');
-  const [openModal, closeModal, Modal] = useModal('MODAL');
+  const [openUnregisterModal, closeUnregisterModal, UnregisterModal] =
+    useModal('MODAL');
 
   const {user, deleteUserInfo} = useUserState();
 
@@ -41,40 +42,6 @@ const MypageProfileScreen = () => {
 
   // const handleUpdateProfileImage = async () => {
   //   openPhotoSelectionAlert();
-  // };
-  // const handlePortalAccountPress = () => {
-  //   if (isVerified) {
-  //       <S.modalWrapper>
-  //         <Txt
-  //           label={'포털 계정 연동을 해지하시겠습니까?'}
-  //           color="grey190"
-  //           typograph="titleMedium"
-  //         />
-  //         <Txt
-  //           label={'연동 해지 시 일부 서비스가 제한될 수 있습니다.'}
-  //           color="grey130"
-  //           typograph="bodySmall"
-  //         />
-  //         <S.Devider />
-  //         <TouchableOpacity
-  //           onPress={() => {
-  //             setIsPortalAuthenticated(false);
-  //             closeModal();
-  //           }}>
-  //           <Txt label={'연동 해지'} color="red" typograph="bodyMedium" />
-  //         </TouchableOpacity>
-  //         <S.Devider />
-  //         <TouchableOpacity onPress={closeModal}>
-  //           <Txt label={'취소'} color="grey90" typograph="bodyMedium" />
-  //         </TouchableOpacity>
-  //       </S.modalWrapper>,
-  //     openModal();
-  //   } else {
-  //     setIsPortalAuthenticated(true);
-  //     navigation.navigate('Mypage_profile', {
-  //       screen: 'Mypage_portalAuthentication',
-  //     });
-  //   }
   // };
 
   const handleGoBack = () => {
@@ -137,13 +104,15 @@ const MypageProfileScreen = () => {
               <NavigationList
                 label="포털 계정 연동"
                 onPress={
-                  !isVerified
-                    ? () => navigation.navigate('Mypage_portalAuthentication')
-                    : undefined
+                  isVerified
+                    ? () =>
+                        navigation.navigate(
+                          'Mypage_portalAuthenticationManagement',
+                        )
+                    : () => navigation.navigate('Mypage_portalAuthentication')
                 }
-                pressLabel={isVerified ? '연동되었습니다.' : '연동하기'}
+                pressLabel={isVerified ? '포털 연동 관리하기' : '연동하기'}
                 pressLabelColor={isVerified ? 'grey130' : 'primaryBrand'}
-                isPressIconShown={!isVerified}
               />
               {isVerified && (
                 <S.portalAccountInformationWrapper>
@@ -169,12 +138,15 @@ const MypageProfileScreen = () => {
                 label="전화번호 변경"
                 onPress={() => navigation.navigate('Mypage_changeNumber')}
               />
-              <NavigationList label="회원탈퇴" onPress={() => openModal()} />
+              <NavigationList
+                label="회원탈퇴"
+                onPress={() => openUnregisterModal()}
+              />
             </S.myProfileBox>
           </S.myProfileContainer>
         </S.screenContainer>
       </View>
-      <Modal>
+      <UnregisterModal>
         <S.UnregisterModalWrapper>
           <Txt
             label="시대생 회원을 탈퇴하시겠습니까?"
@@ -197,10 +169,10 @@ const MypageProfileScreen = () => {
             size="medium"
             variant="text"
             isFullWidth
-            onPress={closeModal}
+            onPress={closeUnregisterModal}
           />
         </S.UnregisterModalWrapper>
-      </Modal>
+      </UnregisterModal>
     </>
   );
 };
@@ -282,6 +254,11 @@ const S = {
   cameraImage: styled.Image`
     width: 13px;
     height: 10.56px;
+  `,
+  PortalTerminationTextWrapper: styled.View`
+    padding: 24px 16px 16px;
+    align-items: center;
+    gap: 8px;
   `,
 };
 

--- a/src/screens/myPage/profile/PortalAuthenticationManagementScreen.tsx
+++ b/src/screens/myPage/profile/PortalAuthenticationManagementScreen.tsx
@@ -1,0 +1,197 @@
+import {useState} from 'react';
+import {View} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useNavigation} from '@react-navigation/native';
+import {useMutation, useQuery} from '@tanstack/react-query';
+import styled from '@emotion/native';
+import {Button, Txt, colors} from '@uoslife/design-system';
+
+import Header from '../../../components/molecules/common/header/Header';
+import {CoreAPI} from '../../../api/services';
+import customShowToast from '../../../configs/toast';
+import UserService from '../../../services/user';
+import useUserState from '../../../hooks/useUserState';
+import useModal from '../../../hooks/useModal';
+
+const PortalAuthenticationManagementScreen = () => {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
+  const {setUserInfo} = useUserState();
+
+  const handleGoBack = () => {
+    navigation.goBack();
+  };
+
+  const [openModal, closeModal, Modal] = useModal('MODAL');
+
+  // handle query
+  const [selectedId, setId] = useState('');
+  const {data} = useQuery({
+    queryKey: ['getPortalVerification'],
+    queryFn: () => CoreAPI.getPortalVerification(),
+  });
+  const representativePortalmutation = useMutation({
+    mutationKey: ['representativePortalVerification'],
+    mutationFn: () =>
+      CoreAPI.representativePortalVerification({
+        studentNumber: selectedId,
+      }),
+    onSuccess: async () => {
+      await UserService.updateUserInfo(setUserInfo);
+      customShowToast('portalVerificationSuccess');
+      navigation.goBack();
+    },
+    onError: () => {
+      customShowToast('portalVerificationError');
+      navigation.goBack();
+    },
+  });
+  const deletePortalmutation = useMutation({
+    mutationKey: ['deletePortalVerification'],
+    mutationFn: () => CoreAPI.deletePortalVerification(),
+    onSuccess: async () => {
+      await CoreAPI.deletePortalVerification();
+      await UserService.updateUserInfo(setUserInfo);
+      customShowToast('deletePortalVerificationSuccess');
+      navigation.goBack();
+    },
+    onError: () => {
+      customShowToast('deletePortalVerificationError');
+      navigation.goBack();
+    },
+  });
+
+  const handlePressChangePortal = () => {
+    if (!selectedId) return;
+    // eslint-disable-next-line consistent-return
+    return representativePortalmutation.mutate();
+  };
+  const handlePressDeletePortal = () => openModal();
+
+  return (
+    <>
+      <S.Container
+        style={{paddingTop: insets.top, paddingBottom: insets.bottom + 16}}>
+        <Header label="포털 연동 관리" onPressBackButton={handleGoBack} />
+        <S.InnerContainer>
+          <S.TopWrapper>
+            <View style={{gap: 8}}>
+              <Txt
+                label="대표 학적과 학번을 선택해주세요."
+                color="grey190"
+                typograph="headlineMedium"
+              />
+              <Txt
+                label="다수의 학적이 있다면 2개 이상이 떠요."
+                color="grey190"
+                typograph="bodyMedium"
+              />
+            </View>
+            {data?.map(item => {
+              return (
+                <S.ButtonSelected
+                  isSelected={item.studentId === selectedId}
+                  onPress={() => setId(item.studentId)}
+                  key={item.studentId}>
+                  <Txt
+                    label={`${item.status}, ${item.studentId}`}
+                    color="grey190"
+                    typograph="titleMedium"
+                  />
+                </S.ButtonSelected>
+              );
+            })}
+          </S.TopWrapper>
+          <S.BottomButtonWrapper>
+            <Button
+              label="포털 연동 변경하기"
+              variant="filled"
+              isFullWidth
+              onPress={handlePressChangePortal}
+              isEnabled={!!selectedId}
+            />
+            <Button
+              label="포털 연동 해지하기"
+              variant="outline"
+              isFullWidth
+              onPress={handlePressDeletePortal}
+            />
+          </S.BottomButtonWrapper>
+        </S.InnerContainer>
+      </S.Container>
+      <Modal>
+        <S.ModalWrapper>
+          <Txt
+            label="포털 연동을 해지하시겠습니까?"
+            color="grey190"
+            typograph="titleMedium"
+            style={{
+              padding: 16,
+              paddingTop: 24,
+              paddingBottom: 0,
+              textAlign: 'center',
+            }}
+          />
+          <Txt
+            label={`포털 연동을 해지하면 시대생에서 제공하는\n여러 서비스를 사용하지 못해요.`}
+            color="grey190"
+            typograph="bodySmall"
+            style={{padding: 16, textAlign: 'center'}}
+          />
+          <S.Divider />
+          <Button
+            label="연동 해지"
+            // labelColor="red"
+            size="medium"
+            variant="text"
+            isFullWidth
+            onPress={deletePortalmutation.mutate}
+          />
+          <S.Divider />
+          <Button
+            label="취소"
+            size="medium"
+            variant="text"
+            isFullWidth
+            onPress={closeModal}
+          />
+        </S.ModalWrapper>
+      </Modal>
+    </>
+  );
+};
+
+export default PortalAuthenticationManagementScreen;
+
+function getBorderColor(isSelected: boolean) {
+  return isSelected ? colors.primaryBrand : colors.grey40;
+}
+
+const S = {
+  Container: styled.View`
+    flex: 1;
+  `,
+  InnerContainer: styled.View`
+    flex: 1;
+    padding: 28px 16px 0;
+    justify-content: space-between;
+  `,
+  TopWrapper: styled.View`
+    gap: 28px;
+  `,
+  ButtonSelected: styled.Pressable<{isSelected: boolean}>`
+    border-radius: 10px;
+    margin-bottom: 16px;
+    padding: 16px;
+    border: 2px solid ${({isSelected}) => getBorderColor(isSelected)};
+  `,
+  BottomButtonWrapper: styled.View`
+    gap: 8px;
+  `,
+  ModalWrapper: styled.View``,
+  Divider: styled.View`
+    width: 100%;
+    height: 1px;
+    background-color: #e1dfdd;
+  `,
+};


### PR DESCRIPTION
## Key Changes
- 수정된 포털 연동 API 스펙을 반영했습니다.

## Details
- 포털연동을 관리하는 '포털연동관리페이지'를 작성하고, 구현했습니다.
- 해당 페이지에서 유저는 '자신의 신분'을 선택 후 업데이트할 수 있고, '포털연동해지'를 할 수 있습니다.
- react native navigation의 'Mypage_changeNickname' params 값에서 type 오류가 발생했기 때문에, isMyPage 타입을 추가하여 해결했습니다.

## Allocated Issue
- close #315 